### PR TITLE
Update to latest shipyard

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -7,7 +7,6 @@ use crate::{
 use shipyard::*;
 use tracing::trace_span;
 
-#[allow(clippy::needless_doctest_main)]
 /// Containers of app logic and data
 pub struct App {
     pub world: World,
@@ -32,7 +31,7 @@ impl App {
     #[track_caller]
     pub fn add_plugin_workload<P>(&mut self, plugin: P) -> AppWorkload
     where
-        P: Plugin + 'static,
+        P: Plugin,
     {
         self.add_plugin_workload_with_info(plugin).0
     }
@@ -40,7 +39,7 @@ impl App {
     #[track_caller]
     pub fn add_plugin_workload_with_info<P>(&mut self, plugin: P) -> (AppWorkload, AppWorkloadInfo)
     where
-        P: Plugin + 'static,
+        P: Plugin,
     {
         let workload_name = type_name::<P>();
         let workload_type_id = TypeId::of::<P>();

--- a/src/app_add_cycle.rs
+++ b/src/app_add_cycle.rs
@@ -85,7 +85,7 @@ impl App {
                         cumulative_update_packed.associate(
                             up_type,
                             CycleWorkloadAssociations {
-                                plugins: assoc,
+                                plugins: assoc.to_vec(),
                                 workload_plugin_id: plugin_id,
                                 workload: name.clone(),
                             },
@@ -99,7 +99,7 @@ impl App {
                         cumulative_tracked_uniques.associate(
                             tracked_type,
                             CycleWorkloadAssociations {
-                                plugins: assoc,
+                                plugins: assoc.to_vec(),
                                 workload: name.clone(),
                                 workload_plugin_id: plugin_id,
                             },
@@ -108,7 +108,7 @@ impl App {
                 }
             }
 
-            names_checked.push(name.clone());
+            names_checked.push(name);
         }
 
         let mut errs = Vec::<CycleCheckError>::new();
@@ -117,12 +117,11 @@ impl App {
         errs.extend(
             cumulative_update_packed
                 .entries()
-                .into_iter()
-                .filter(|((_, _), workloads_dependent)| workloads_dependent.len() > 1)
+                .filter(|(_, workloads_dependent)| workloads_dependent.len() > 1)
                 .map(|((_, update_pack_storage_name), workloads_dependent)| {
                     CycleCheckError::UpdatePackResetInMultipleWorkloads {
                         update_pack: update_pack_storage_name,
-                        conflicts: workloads_dependent,
+                        conflicts: workloads_dependent.to_vec(),
                     }
                 }),
         );
@@ -131,12 +130,11 @@ impl App {
         errs.extend(
             cumulative_tracked_uniques
                 .entries()
-                .into_iter()
-                .filter(|((_, _), workloads_dependent)| workloads_dependent.len() > 1)
+                .filter(|(_, workloads_dependent)| workloads_dependent.len() > 1)
                 .map(|((_, tracked_unique_storage_name), workloads_dependent)| {
                     CycleCheckError::TrackedUniqueResetInMultipleWorkloads {
                         tracked_unique: tracked_unique_storage_name,
-                        conflicts: workloads_dependent,
+                        conflicts: workloads_dependent.to_vec(),
                     }
                 }),
         );

--- a/src/app_builder.rs
+++ b/src/app_builder.rs
@@ -325,7 +325,8 @@ impl<'a> AppBuilder<'a> {
             .is_first()
         {
             self.app.world.borrow::<ViewMut<T>>().unwrap().update_pack();
-            self.resets.push(system!(reset_update_pack::<T>));
+            self.resets
+                .push(reset_update_pack::<T>.into_workload_system().unwrap());
         }
 
         self
@@ -340,7 +341,8 @@ impl<'a> AppBuilder<'a> {
             .associate_plugin::<T>(&self.track_current_plugin, reason)
             .is_first()
         {
-            self.resets.push(system!(reset_tracked_unique::<T>));
+            self.resets
+                .push(reset_tracked_unique::<T>.into_workload_system().unwrap());
         }
 
         self
@@ -443,8 +445,8 @@ impl<'a> AppBuilder<'a> {
     }
 
     #[track_caller]
-    pub fn add_system(&mut self, system: WorkloadSystem) -> &mut Self {
-        self.systems.push(system);
+    pub fn add_system<B, R, S: IntoWorkloadSystem<B, R>>(&mut self, system: S) -> &mut Self {
+        self.systems.push(system.into_workload_system().unwrap());
 
         self
     }

--- a/src/app_builder.rs
+++ b/src/app_builder.rs
@@ -35,13 +35,12 @@ pub(crate) struct TypeIdBuckets<T> {
     pub(crate) type_plugins_lookup: HashMap<TypeId, Vec<T>>,
 }
 
-impl<T: std::fmt::Debug + Clone> std::fmt::Debug for TypeIdBuckets<T> {
+impl<T: std::fmt::Debug> std::fmt::Debug for TypeIdBuckets<T> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_map()
             .entry(&"association", &self.name)
             .entries(
                 self.entries()
-                    .into_iter()
                     .map(|((_, name), associated)| (name, associated)),
             )
             .finish()
@@ -68,18 +67,17 @@ impl<T> TypeIdBuckets<T> {
     }
 }
 
-impl<T: Clone + std::fmt::Debug> TypeIdBuckets<T> {
-    pub(crate) fn entries(&self) -> Vec<((TypeId, &'static str), Vec<T>)> {
-        self.type_plugins_lookup
-            .iter()
-            .map(|(id, associations)| -> ((TypeId, &'static str), Vec<T>) {
+impl<T: std::fmt::Debug> TypeIdBuckets<T> {
+    pub(crate) fn entries(&self) -> impl Iterator<Item = ((TypeId, &'static str), &[T])> + '_ {
+        self.type_plugins_lookup.iter().map(
+            move |(id, associations)| -> ((TypeId, &'static str), &[T]) {
                 let name = self
                     .track_type_names
                     .lookup_name(&id)
                     .expect("all type ids with associations have a name saved");
-                ((*id, name), associations.to_vec())
-            })
-            .collect()
+                ((*id, name), associations)
+            },
+        )
     }
 
     pub(crate) fn associate_type<U: 'static>(&mut self, assoc: T) -> AssociateResult {
@@ -219,9 +217,9 @@ pub struct AppWorkloadInfo {
 }
 
 #[derive(Clone)]
-pub(crate) struct Blind<T: Clone + 'static>(pub T);
+pub(crate) struct Blind<T>(pub T);
 
-impl<T: Clone + 'static> std::fmt::Debug for Blind<T> {
+impl<T> std::fmt::Debug for Blind<T> {
     fn fmt(&self, mut f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(&mut f, "Blind<{}>", type_name::<T>())
     }
@@ -234,7 +232,7 @@ impl AppWorkload {
         for workload_name in self.names.iter() {
             let span = trace_span!("AppWorkload::run", ?workload_name);
             let _span = span.enter();
-            app.world.run_workload(&workload_name).unwrap();
+            app.world.run_workload(workload_name).unwrap();
         }
     }
 }
@@ -282,17 +280,10 @@ impl<'a> AppBuilder<'a> {
             signature,
         } = self;
 
-        let mut update_workload = systems.into_iter().fold(
-            WorkloadBuilder::new(update_stage.clone()),
-            |mut acc: WorkloadBuilder, system: WorkloadSystem| {
-                acc.with_system(system);
-                acc
-            },
-        );
+        let mut update_workload = WorkloadBuilder::new(update_stage.clone());
 
-        for reset_system in resets {
-            update_workload.with_system(reset_system);
-        }
+        update_workload.extend(systems);
+        update_workload.extend(resets);
 
         let info = update_workload.add_to_world_with_info(&app.world).unwrap();
         (

--- a/src/test/tree.rs
+++ b/src/test/tree.rs
@@ -34,7 +34,7 @@ impl Plugin for TreePlugin {
     fn build(&self, app: &mut AppBuilder) {
         // needs direct update pack since TreePlugin clears updates on its own.
         app.update_pack::<ChildOf>("update in response to ChildOf changes")
-            .add_system(system!(indexing::tree_indexing));
+            .add_system(&indexing::tree_indexing);
     }
 }
 
@@ -57,11 +57,11 @@ mod tests {
         let mut indexing = WorkloadBuilder::new("indexing");
 
         indexing
-            .with_system(system!(indexing::tree_indexing))
-            .with_system(system!(|mut vm_child_of: ViewMut<ChildOf>| {
+            .with_system(&indexing::tree_indexing)
+            .with_system(&|mut vm_child_of: ViewMut<ChildOf>| {
                 vm_child_of.clear_all_inserted_and_modified();
                 vm_child_of.take_deleted();
-            }))
+            })
             .add_to_world(&world)
             .unwrap();
 
@@ -497,10 +497,10 @@ mod tests {
         });
 
         WorkloadBuilder::new("default")
-            .with_system(system!(indexing::tree_indexing))
-            .with_system(system!(|mut vm_child_of: ViewMut<ChildOf>| {
+            .with_system(&indexing::tree_indexing)
+            .with_system(&|mut vm_child_of: ViewMut<ChildOf>| {
                 vm_child_of.clear_all_inserted_and_modified();
-            }))
+            })
             .add_to_world(&app.world)
             .unwrap();
 

--- a/src/tracked_unique.rs
+++ b/src/tracked_unique.rs
@@ -6,9 +6,9 @@ use crate::prelude::*;
 use core::any::type_name;
 use std::{fmt, ops::Deref, ops::DerefMut};
 
-pub struct TrackedValue<T: 'static>(InnerTrackedState, T);
+pub struct TrackedValue<T>(InnerTrackedState, T);
 
-pub struct Tracked<'a, T: 'static>(UniqueView<'a, TrackedValue<T>>);
+pub struct Tracked<'a, T>(UniqueView<'a, TrackedValue<T>>);
 
 pub struct TrackedBorrower<T>(T);
 
@@ -42,9 +42,9 @@ unsafe impl<'a, T: 'static + Send + Sync> BorrowInfo for Tracked<'a, T> {
     }
 }
 
-pub struct TrackedMut<'a, T: 'static>(UniqueViewMut<'a, TrackedValue<T>>);
+pub struct TrackedMut<'a, T>(UniqueViewMut<'a, TrackedValue<T>>);
 
-pub struct TrackedMutBorrower<T: 'static>(T);
+pub struct TrackedMutBorrower<T>(T);
 
 impl<'a, T: 'static + Send + Sync> IntoBorrow for TrackedMut<'a, T> {
     type Borrow = TrackedMutBorrower<T>;
@@ -102,7 +102,7 @@ impl<T> Tracked<'_, T> {
     }
 }
 
-impl<T: 'static> Deref for Tracked<'_, T> {
+impl<T> Deref for Tracked<'_, T> {
     type Target = T;
 
     #[inline(always)]
@@ -111,7 +111,7 @@ impl<T: 'static> Deref for Tracked<'_, T> {
     }
 }
 
-impl<T: 'static> Deref for TrackedMut<'_, T> {
+impl<T> Deref for TrackedMut<'_, T> {
     type Target = T;
 
     #[inline(always)]
@@ -120,7 +120,7 @@ impl<T: 'static> Deref for TrackedMut<'_, T> {
     }
 }
 
-impl<T: 'static> DerefMut for TrackedMut<'_, T> {
+impl<T> DerefMut for TrackedMut<'_, T> {
     #[inline(always)]
     fn deref_mut(&mut self) -> &mut T {
         self.0 .0 = InnerTrackedState::Modified;
@@ -128,31 +128,31 @@ impl<T: 'static> DerefMut for TrackedMut<'_, T> {
     }
 }
 
-impl<T: 'static> AsRef<T> for Tracked<'_, T> {
+impl<T> AsRef<T> for Tracked<'_, T> {
     fn as_ref(&self) -> &T {
-        &**self
+        &*self
     }
 }
 
-impl<T: 'static> AsRef<T> for TrackedMut<'_, T> {
+impl<T> AsRef<T> for TrackedMut<'_, T> {
     fn as_ref(&self) -> &T {
-        &**self
+        &*self
     }
 }
 
-impl<T: 'static> AsMut<T> for TrackedMut<'_, T> {
+impl<T> AsMut<T> for TrackedMut<'_, T> {
     fn as_mut(&mut self) -> &mut T {
-        &mut **self
+        &mut *self
     }
 }
 
-impl<T: 'static + fmt::Display> fmt::Display for Tracked<'_, T> {
+impl<T: fmt::Display> fmt::Display for Tracked<'_, T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Display::fmt(&**self, f)
     }
 }
 
-impl<T: 'static + fmt::Debug> fmt::Debug for Tracked<'_, T> {
+impl<T: fmt::Debug> fmt::Debug for Tracked<'_, T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Debug::fmt(&**self, f)
     }
@@ -160,7 +160,7 @@ impl<T: 'static + fmt::Debug> fmt::Debug for Tracked<'_, T> {
 
 /// Add [TrackedUnique] of `T` and reset tracking at the end of every update.
 #[derive(Default)]
-pub struct TrackedUniquePlugin<T: Clone + Send + Sync + 'static>(T);
+pub struct TrackedUniquePlugin<T>(T);
 
 impl<T: Clone + Send + Sync + 'static> TrackedUniquePlugin<T> {
     pub fn new(initial_value: T) -> Self {

--- a/src/type_names.rs
+++ b/src/type_names.rs
@@ -19,6 +19,6 @@ impl TypeNames {
     }
 
     pub fn lookup_name(&self, type_id: &TypeId) -> Option<&'static str> {
-        self.0.borrow().get(type_id).map(|a| *a as &'static str)
+        self.0.borrow().get(type_id).copied()
     }
 }


### PR DESCRIPTION
Hi, this PR uses the new borrowing and system construction. I don't know when you'll use this version of shipyard but this crate will be ready.

I also simplified tests by using methods directly on `World`. I'm not sure it's something you want but it's there just in case =)

I should've made another branch for the last commit... I guess it's a bit late.
This last commit is even more up to personal preference, cherry pick anything you like.
About `TypeIdBuckets::entries` I don't think the outer `Vec` is useful, the inner one might be best kept as `Vec`.